### PR TITLE
Add option to publish sensor name in MQTT payload

### DIFF
--- a/wyzesense2mqtt/config/config.yaml.sample
+++ b/wyzesense2mqtt/config/config.yaml.sample
@@ -9,4 +9,5 @@ mqtt_qos: 2
 mqtt_retain: true
 self_topic_root: wyzesense2mqtt
 hass_topic_root: homeassistant
+publish_sensor_name: true
 usb_dongle: auto

--- a/wyzesense2mqtt/wyzesense2mqtt.py
+++ b/wyzesense2mqtt/wyzesense2mqtt.py
@@ -361,6 +361,10 @@ def on_event(WYZESENSE_DONGLE, event):
                 'signal_strength': sensor_signal * -1,
                 'battery': sensor_battery
             }
+
+            if ('publish_sensor_name' in CONFIG and CONFIG['publish_sensor_name'] == True):
+                event_payload['name'] = SENSORS[event.MAC]['name']
+
             if (SENSORS[event.MAC].get('invert_state') == True):
                 event_payload['state'] = (0 if (sensor_state == "open") or
                                                (sensor_state == "active")


### PR DESCRIPTION
This PR implements the feature mentioned in #25, but with the ability to enable/disable via `config.yaml`. The feature defaults to being disabled, but can be enabled by setting `publish_sensor_name: true` in `config.yaml`.

A failsafe was included to prevent errors if `publish_sensor_name` is not defined in `config.yaml` (for example: an upgrade that maintains the previous configuration).

Credit to @dennyfmn for this feature.