### PR TITLE
Resolve most flake8 issues

### DIFF
--- a/wyzesense2mqtt/samples/config.yaml
+++ b/wyzesense2mqtt/samples/config.yaml
@@ -5,7 +5,7 @@ mqtt_password: <password>
 mqtt_client_id: wyzesense2mqtt
 mqtt_clean_session: false
 mqtt_keepalive: 60
-mqtt_qos: 2
+mqtt_qos: 0
 mqtt_retain: true
 self_topic_root: wyzesense2mqtt
 hass_topic_root: homeassistant

--- a/wyzesense2mqtt/wyzesense2mqtt.py
+++ b/wyzesense2mqtt/wyzesense2mqtt.py
@@ -14,6 +14,7 @@ import paho.mqtt.client as mqtt
 import wyzesense
 from retrying import retry
 
+
 # Configuration File Locations
 CONFIG_PATH = "config/"
 SAMPLES_PATH = "samples/"
@@ -143,9 +144,10 @@ def init_sensors():
     else:
         LOGGER.info("No sensors config file found.")
 
+    # Add invert_state value if missing
     for sensor_mac in SENSORS:
-        if (valid_sensor_mac(sensor_mac)):
-            send_discovery_topics(sensor_mac)
+        if (SENSORS[sensor_mac].get('invert_state') is None):
+            SENSORS[sensor_mac]['invert_state'] = False
 
     # Check config against linked sensors
     try:
@@ -156,11 +158,15 @@ def init_sensors():
                 if (valid_sensor_mac(sensor_mac)):
                     if (SENSORS.get(sensor_mac) is None):
                         add_sensor_to_config(sensor_mac, None, None)
-                        send_discovery_topics(sensor_mac)
         else:
             LOGGER.warning(f"Sensor list failed with result: {result}")
     except TimeoutError:
         pass
+
+    # Send discovery topics
+    for sensor_mac in SENSORS:
+        if (valid_sensor_mac(sensor_mac)):
+            send_discovery_topics(sensor_mac)
 
 
 # Validate sensor MAC


### PR DESCRIPTION
Resolve all flake8 issues except for [E501](https://www.flake8rules.com/rules/E501.html) and [E722](https://www.flake8rules.com/rules/E722.html).

```
pi@wyzesense2mqtt:/etc/wyzesense2mqtt $ flake8 --ignore=E501,W503,E722 .
pi@wyzesense2mqtt:/etc/wyzesense2mqtt $ flake8 .
./wyzesense2mqtt/wyzesense2mqtt.py:383:80: E501 line too long (83 > 79 characters)
./wyzesense2mqtt/wyzesense.py:75:80: E501 line too long (85 > 79 characters)
./wyzesense2mqtt/wyzesense.py:77:80: E501 line too long (92 > 79 characters)
./wyzesense2mqtt/wyzesense.py:142:80: E501 line too long (90 > 79 characters)
./wyzesense2mqtt/wyzesense.py:220:80: E501 line too long (88 > 79 characters)
./wyzesense2mqtt/wyzesense.py:236:80: E501 line too long (81 > 79 characters)
./wyzesense2mqtt/wyzesense.py:238:80: E501 line too long (90 > 79 characters)
./wyzesense2mqtt/wyzesense.py:240:80: E501 line too long (84 > 79 characters)
./wyzesense2mqtt/wyzesense.py:257:80: E501 line too long (84 > 79 characters)
./wyzesense2mqtt/wyzesense.py:271:80: E501 line too long (118 > 79 characters)
./wyzesense2mqtt/wyzesense.py:273:80: E501 line too long (87 > 79 characters)
./wyzesense2mqtt/wyzesense.py:464:80: E501 line too long (86 > 79 characters)
./wyzesense2mqtt/wyzesense.py:469:80: E501 line too long (80 > 79 characters)
./wyzesense2mqtt/wyzesense.py:476:80: E501 line too long (104 > 79 characters)
./wyzesense2mqtt/wyzesense.py:499:9: E722 do not use bare 'except'
./wyzesense2mqtt/wyzesense.py:523:80: E501 line too long (92 > 79 characters)
./wyzesense2mqtt/wyzesense.py:532:80: E501 line too long (94 > 79 characters)
./wyzesense2mqtt/wyzesense.py:552:80: E501 line too long (87 > 79 characters)
./wyzesense2mqtt/wyzesense.py:553:80: E501 line too long (103 > 79 characters)
./wyzesense2mqtt/bridge_tool_cli.py:2:80: E501 line too long (99 > 79 characters)
./wyzesense2mqtt/bridge_tool_cli.py:75:80: E501 line too long (83 > 79 characters)
./wyzesense2mqtt/bridge_tool_cli.py:76:80: E501 line too long (91 > 79 characters)
./wyzesense2mqtt/bridge_tool_cli.py:85:80: E501 line too long (82 > 79 characters)
```

I am not 100% sure how to address the remaining rules, so I didn't touch them.