### PR TITLE
Major updates and fixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,8 @@ sudo systemctl start wyzesense2mqtt
 sudo systemctl status wyzesense2mqtt
 sudo systemctl enable wyzesense2mqtt # Enable start on reboot
 ```
-9. Pair sensors following [instructions below](#pairing-a-sensor). You do NOT need to re-pair sensors that were already paired, they should be found automatically on start and added to the config file with default values, but the sensor version will be unknown.
+9. Pair sensors following [instructions below](#pairing-a-sensor). You do NOT need to re-pair sensors that were already paired, they should be found automatically on start and added to the config file with default values, but the sensor version will be unknown and the 
+class will default to opening, I.E. a contact sensor.
 
 
 ## Config Files
@@ -179,16 +180,22 @@ root:
 ```
 
 ### sensors.yaml
-This file will store basic information about each sensor paired to the Wyse Sense Bridge. The entries can be modified to set the class type and sensor name as it will show in Home Assistant. Class types can be automatically filled for `opening`, `motion`, and `moisture`, depending on the type of sensor. Since this file can be automatically generated, Python may automatically quote the MACs or not depending on if they are fully numeric.
+This file will store basic information about each sensor paired to the Wyse Sense Bridge. The entries can be modified to set the class type and sensor name as it will show in Home Assistant. Class types can be automatically filled for `opening`, `motion`, and `moisture`, 
+depending on the type of sensor. Since this file can be automatically generated, Python may automatically quote the MACs or not depending on if they are fully numeric. Sensors that were previously linked and automatically added will default to class `opening` and will not 
+have a "sw_version" set. For the original version 1 devices, the sw_version should be 19. For the newer version 2 devices, the sw_version should be 23. This will be automatically have the correct settings for devices added via a scan. A custom timeout for device 
+availability can also be added per device by setting the "timeout" setting, in seconds. For version 1 devices, the default timeout is 8 hours and for version 2 device, the default timeout is 4 hours.
 ```yaml
 'AAAAAAAA':
   class: door
   name: Entry Door
   invert_state: false
+  sw_version: 19
 'BBBBBBBB':
   class: window
   name: Office Window
   invert_state: false
+  sw_version: 23
+  timeout: 7200
 'CCCCCCCC':
   class: opening
   name: Kitchen Fridge

--- a/wyzesense2mqtt/bridge_tool_cli.py
+++ b/wyzesense2mqtt/bridge_tool_cli.py
@@ -46,9 +46,9 @@ def main(args):
         logging.getLogger().setLevel(loglevel)
 
     device = args['--device']
-    print(f"Openning wyzesense gateway [{device}]")
+    print(f"Opening wyzesense gateway [{device}]")
     try:
-        ws = wyzesense.Open(device, on_event)
+        ws = wyzesense.Open(device, on_event, logging.getLogger())
         if not ws:
             print("Open wyzesense gateway failed")
             return 1

--- a/wyzesense2mqtt/samples/logging.yaml
+++ b/wyzesense2mqtt/samples/logging.yaml
@@ -9,7 +9,7 @@ handlers:
   console:
     class: logging.StreamHandler
     formatter: simple
-    level: DEBUG
+    level: INFO
   file:
     backupCount: 7
     class: logging.handlers.TimedRotatingFileHandler
@@ -22,4 +22,4 @@ root:
   handlers:
     - file
     - console
-  level: DEBUG
+  level: INFO

--- a/wyzesense2mqtt/wyzesense2mqtt.py
+++ b/wyzesense2mqtt/wyzesense2mqtt.py
@@ -9,10 +9,7 @@ import os
 import shutil
 import subprocess
 import yaml
-
-# Used for alternate MQTT connection method
-# import signal
-# import time
+import time
 
 import paho.mqtt.client as mqtt
 import wyzesense
@@ -25,6 +22,8 @@ SAMPLES_PATH = "samples"
 MAIN_CONFIG_FILE = "config.yaml"
 LOGGING_CONFIG_FILE = "logging.yaml"
 SENSORS_CONFIG_FILE = "sensors.yaml"
+SENSORS_STATE_FILE = "state.yaml"
+
 
 # Simplify mapping of device classes.
 # { **dict.fromkeys(['list', 'of', 'possible', 'identifiers'], 'device_class') }
@@ -33,6 +32,33 @@ DEVICE_CLASSES = {
     **dict.fromkeys([0x02, 0x0F, 'motion', 'motionv2'], 'motion'),
     **dict.fromkeys([0x03, 'leak'], 'moisture')
 }
+
+
+# List of states that correlate to ON.
+STATES_ON = ['active', 'open', 'wet']
+
+# Oldest state data that is considered fresh, older state data is stale and ignored
+# 1 hour, converted to seconds
+STALE_STATE = 1*60*60
+
+# Keep persistant data about the sensors that isn't configurable in a seperate state variable
+# Read/write this file to try and maintain a consistent state
+SENSORS_STATE = {}
+
+
+# V1 sensors send state every 4 hours, V2 sensors send every 2 hours
+# For timeout of availability, use 2 times the report period to allow
+# for one missed message. If 2 are missed, then the sensor probably is
+# offline.
+DEFAULT_V1_TIMEOUT_HOURS = 8
+DEFAULT_V2_TIMEOUT_HOURS = 4
+
+
+# List of sw versions for V1 and V2 sensors, to determine which timeout to use by default
+V1_SW=[19]
+V2_SW=[23]
+
+INITIALIZED = False
 
 # Read data from YAML file
 def read_yaml_file(filename):
@@ -78,13 +104,13 @@ def init_logging():
         print("Unable to create log folder")
     logging.config.dictConfig(logging_config)
     LOGGER = logging.getLogger("wyzesense2mqtt")
-    LOGGER.debug("Logging initialized...")
+    LOGGER.info("Logging initialized...")
 
 
 # Initialize configuration
 def init_config():
     global CONFIG
-    LOGGER.debug("Initializing configuration...")
+    LOGGER.info("Initializing configuration...")
 
     # load base config - allows for auto addition of new settings
     if (os.path.isfile(os.path.join(SAMPLES_PATH, MAIN_CONFIG_FILE))):
@@ -110,7 +136,7 @@ def init_config():
 def init_mqtt_client():
     global MQTT_CLIENT, CONFIG, LOGGER
     # Used for alternate MQTT connection method
-    # mqtt.Client.connected_flag = False
+    mqtt.Client.connected_flag = False
 
     # Configure MQTT Client
     MQTT_CLIENT = mqtt.Client(client_id=CONFIG['mqtt_client_id'], clean_session=CONFIG['mqtt_clean_session'])
@@ -126,10 +152,12 @@ def init_mqtt_client():
     MQTT_CLIENT.connect_async(CONFIG['mqtt_host'], port=CONFIG['mqtt_port'], keepalive=CONFIG['mqtt_keepalive'])
 
     # Used for alternate MQTT connection method
-    # MQTT_CLIENT.loop_start()
-    # while (not MQTT_CLIENT.connected_flag):
-    #     time.sleep(1)
+    MQTT_CLIENT.loop_start()
+    while (not MQTT_CLIENT.connected_flag):
+        time.sleep(1)
 
+    # Make sure the service stays marked as offline until everything is initialized
+    mqtt_publish(f"{CONFIG['self_topic_root']}/status", "offline", is_json=False)
 
 # Retry forever on IO Error
 def retry_if_io_error(exception):
@@ -139,11 +167,9 @@ def retry_if_io_error(exception):
 # Initialize USB dongle
 @retry(wait_exponential_multiplier=1000, wait_exponential_max=30000, retry_on_exception=retry_if_io_error)
 def init_wyzesense_dongle():
-    global WYZESENSE_DONGLE, CONFIG
+    global WYZESENSE_DONGLE, CONFIG, LOGGER
     if (CONFIG['usb_dongle'].lower() == "auto"):
-        device_list = subprocess.check_output(
-            ["ls", "-la", "/sys/class/hidraw"]
-        ).decode("utf-8").lower()
+        device_list = subprocess.check_output(["ls", "-la", "/sys/class/hidraw"]).decode("utf-8").lower()
         for line in device_list.split("\n"):
             if (("e024" in line) and ("1a86" in line)):
                 for device_name in line.split(" "):
@@ -153,28 +179,28 @@ def init_wyzesense_dongle():
 
     LOGGER.info(f"Connecting to dongle {CONFIG['usb_dongle']}")
     try:
-        WYZESENSE_DONGLE = wyzesense.Open(CONFIG['usb_dongle'], on_event)
-        LOGGER.debug(f"Dongle {CONFIG['usb_dongle']}: ["
-                     f" MAC: {WYZESENSE_DONGLE.MAC},"
-                     f" VER: {WYZESENSE_DONGLE.Version},"
-                     f" ENR: {WYZESENSE_DONGLE.ENR}]")
+        WYZESENSE_DONGLE = wyzesense.Open(CONFIG['usb_dongle'], on_event, LOGGER)
+        LOGGER.info(f"Dongle {CONFIG['usb_dongle']}: ["
+                    f" MAC: {WYZESENSE_DONGLE.MAC},"
+                    f" VER: {WYZESENSE_DONGLE.Version},"
+                    f" ENR: {WYZESENSE_DONGLE.ENR}]")
     except IOError as error:
-        LOGGER.warning(f"No device found on path {CONFIG['usb_dongle']}: {str(error)}")
+        LOGGER.error(f"No device found on path {CONFIG['usb_dongle']}: {str(error)}")
 
 
 # Initialize sensor configuration
-def init_sensors():
+def init_sensors(wait=True):
     # Initialize sensor dictionary
-    global SENSORS
+    global SENSORS, SENSORS_STATE
     SENSORS = {}
 
     # Load config file
-    LOGGER.debug("Reading sensors configuration...")
     if (os.path.isfile(os.path.join(CONFIG_PATH, SENSORS_CONFIG_FILE))):
+        LOGGER.info("Reading sensors configuration...")
         SENSORS = read_yaml_file(os.path.join(CONFIG_PATH, SENSORS_CONFIG_FILE))
         sensors_config_file_found = True
     else:
-        LOGGER.info("No sensors config file found.")
+        LOGGER.warning("No sensors config file found.")
         sensors_config_file_found = False
 
     # Add invert_state value if missing
@@ -182,19 +208,71 @@ def init_sensors():
         if (SENSORS[sensor_mac].get('invert_state') is None):
             SENSORS[sensor_mac]['invert_state'] = False
 
+    # Load previous known states
+    if (os.path.isfile(os.path.join(CONFIG_PATH, SENSORS_STATE_FILE))):
+        LOGGER.info("Reading sensors last known state...")
+        SENSORS_STATE = read_yaml_file(os.path.join(CONFIG_PATH, SENSORS_STATE_FILE))
+        if (SENSORS_STATE.get('modified') is not None):
+            if ((time.time() - SENSORS_STATE['modified']) > STALE_STATE):
+                LOGGER.warning("Ignoring stale state data")
+                SENSORS_STATE = {}
+            else:
+                # Remove this field so we don't get a bogus warning below
+                del SENSORS_STATE['modified']
+
     # Check config against linked sensors
+    checked_linked = False
     try:
+        LOGGER.info("Checking sensors against dongle list...")
         result = WYZESENSE_DONGLE.List()
-        LOGGER.debug(f"Linked sensors: {result}")
         if (result):
+            checked_linked = True
+
             for sensor_mac in result:
                 if (valid_sensor_mac(sensor_mac)):
                     if (SENSORS.get(sensor_mac) is None):
                         add_sensor_to_config(sensor_mac, None, None)
+                        LOGGER.warning(f"Linked sensor with mac {sensor_mac} automatically added to sensors configuration")
+                        LOGGER.warning(f"Please update sensor configuration file {os.path.join(CONFIG_PATH, SENSORS_CONFIG_FILE)} restart the service/reload the sensors")
+
+                    # If not a configured sensor, then adding it will also add it to the state
+                    # So only check if in the state if it is a configured sensor
+                    elif (SENSORS_STATE.get(sensor_mac) is None):
+                        # Only track state for linked sensors
+                        # If it wasn't configured, it'd get added above, including in state
+                        # Intialize last seen time to now and start online
+                        SENSORS_STATE[sensor_mac] = {
+                            'last_seen': time.time(),
+                            'online': True
+                        }
+
+            # We could save sensor state for sensors that aren't linked to the dongle if we fail
+            # to check, then add a configured sensor to the state which gets written on stop. The
+            # Next run it'll add the bad state mac. So to help with that, when we do check the
+            # linked sensors, we should also remove anything in the state that wasn't linked
+            delete = [sensor_mac for sensor_mac in SENSORS_STATE if sensor_mac not in result]
+            for sensor_mac in delete:
+                del SENSORS_STATE[sensor_mac]
+                LOGGER.info(f"Removed unlinked sensor ({sensor_mac}) from state")
+
         else:
             LOGGER.warning(f"Sensor list failed with result: {result}")
+
     except TimeoutError:
+        LOGGER.error("Dongle list timeout")
         pass
+
+    if not checked_linked:
+        # Unable to get linked sensors
+        # Make sure all configured sensors have a state
+        for sensor_mac in SENSORS:
+            if (SENSORS_STATE.get(sensor_mac) is None):
+                # Intialize last seen time to now and start online
+                SENSORS_STATE[sensor_mac] = {
+                    'last_seen': time.time(),
+                    'online': True
+                }
+
 
     # Save sensors file if didn't exist
     if (not sensors_config_file_found):
@@ -203,19 +281,19 @@ def init_sensors():
 
     # Send discovery topics
     if(CONFIG['hass_discovery']):
-        for sensor_mac in SENSORS:
+        for sensor_mac in SENSORS_STATE:
             if (valid_sensor_mac(sensor_mac)):
-                send_discovery_topics(sensor_mac)
+                send_discovery_topics(sensor_mac, wait=wait)
 
 
 # Validate sensor MAC
 def valid_sensor_mac(sensor_mac):
-    #LOGGER.debug(f"Validating MAC: {sensor_mac}")
     invalid_mac_list = [
         "00000000",
         "\0\0\0\0\0\0\0\0",
         "\x00\x00\x00\x00\x00\x00\x00\x00"
     ]
+
     if ((len(str(sensor_mac)) == 8) and (sensor_mac not in invalid_mac_list)):
         return True
     else:
@@ -224,52 +302,65 @@ def valid_sensor_mac(sensor_mac):
             WYZESENSE_DONGLE.Delete(sensor_mac)
             clear_topics(sensor_mac)
         except TimeoutError:
-            pass
-        return False
+            LOGGER.error("Timeout removing bad mac")
+    return False
 
 
 # Add sensor to config
 def add_sensor_to_config(sensor_mac, sensor_type, sensor_version):
-    global SENSORS
+    global SENSORS, SENSORS_STATE
     LOGGER.info(f"Adding sensor to config: {sensor_mac}")
     SENSORS[sensor_mac] = {
         'name': f"Wyze Sense {sensor_mac}",
-        'class': DEVICE_CLASSES.get(sensor_type),
         'invert_state': False
     }
+
+    SENSORS[sensor_mac]['class'] = "opening" if sensor_type is None else DEVICE_CLASSES.get(sensor_type)
+
     if (sensor_version is not None):
         SENSORS[sensor_mac]['sw_version'] = sensor_version
+
+    # Intialize last seen time to now and start online
+    SENSORS_STATE[sensor_mac] = {
+        'last_seen': time.time(),
+        'online': True
+    }
 
     write_yaml_file(os.path.join(CONFIG_PATH, SENSORS_CONFIG_FILE), SENSORS)
 
 
 # Delete sensor from config
 def delete_sensor_from_config(sensor_mac):
-    global SENSORS
+    global SENSORS, SENSORS_STATE
     LOGGER.info(f"Deleting sensor from config: {sensor_mac}")
     try:
         del SENSORS[sensor_mac]
         write_yaml_file(os.path.join(CONFIG_PATH, SENSORS_CONFIG_FILE), SENSORS)
+        del SENSORS_STATE[sensor_mac]
     except KeyError:
-        LOGGER.debug(f"{sensor_mac} not found in SENSORS")
+        LOGGER.error(f"{sensor_mac} not found in SENSORS")
 
 
 # Publish MQTT topic
-def mqtt_publish(mqtt_topic, mqtt_payload):
+def mqtt_publish(mqtt_topic, mqtt_payload, is_json=True, wait=True):
     global MQTT_CLIENT, CONFIG
     mqtt_message_info = MQTT_CLIENT.publish(
         mqtt_topic,
-        payload=json.dumps(mqtt_payload),
+        payload=(json.dumps(mqtt_payload) if is_json else mqtt_payload),
         qos=CONFIG['mqtt_qos'],
         retain=CONFIG['mqtt_retain']
     )
-    if (mqtt_message_info.rc != mqtt.MQTT_ERR_SUCCESS):
-        LOGGER.warning(f"MQTT publish error: {mqtt.error_string(mqtt_message_info.rc)}")
+    if (mqtt_message_info.rc == mqtt.MQTT_ERR_SUCCESS):
+        if (wait):
+            mqtt_message_info.wait_for_publish(2)
+        return
+
+    LOGGER.warning(f"MQTT publish error: {mqtt.error_string(mqtt_message_info.rc)}")
 
 
 # Send discovery topics
-def send_discovery_topics(sensor_mac):
-    global SENSORS, CONFIG
+def send_discovery_topics(sensor_mac, wait=True):
+    global SENSORS, CONFIG, SENSORS_STATE
 
     LOGGER.info(f"Publishing discovery topics for {sensor_mac}")
 
@@ -288,48 +379,63 @@ def send_discovery_topics(sensor_mac):
             else "Sense Contact Sensor"
         ),
         'name': sensor_name,
-        'sw_version': sensor_version
+        'sw_version': sensor_version,
+        'via_device': "wyzesense2mqtt"
     }
+
+    mac_topic = f"{CONFIG['self_topic_root']}/{sensor_mac}"
 
     entity_payloads = {
         'state': {
             'name': sensor_name,
-            'dev_cla': sensor_class,
-            'pl_on': "1",
-            'pl_off': "0",
-            'json_attr_t': f"{CONFIG['self_topic_root']}/{sensor_mac}"
+            'device_class': sensor_class,
+            'payload_on': "1",
+            'payload_off': "0",
+            'json_attributes_topic': mac_topic
         },
         'signal_strength': {
             'name': f"{sensor_name} Signal Strength",
-            'dev_cla': "signal_strength",
-            'unit_of_meas': "dBm"
+            'device_class': "signal_strength",
+            'state_class': "measurement",
+            'unit_of_measurement': "dBm",
+            'entity_category': "diagnostic"
         },
         'battery': {
             'name': f"{sensor_name} Battery",
-            'dev_cla': "battery",
-            'unit_of_meas': "%"
+            'device_class': "battery",
+            'state_class': "measurement",
+            'unit_of_measurement': "%",
+            'entity_category': "diagnostic"
         }
     }
 
+    availability_topics = [
+        { 'topic': f"{CONFIG['self_topic_root']}/{sensor_mac}/status" },
+        { 'topic': f"{CONFIG['self_topic_root']}/status" }
+    ]
+
     for entity, entity_payload in entity_payloads.items():
-        entity_payload['val_tpl'] = f"{{{{ value_json.{entity} }}}}"
-        entity_payload['uniq_id'] = f"wyzesense_{sensor_mac}_{entity}"
-        entity_payload['stat_t'] = f"{CONFIG['self_topic_root']}/{sensor_mac}"
-        entity_payload['dev'] = device_payload
-        sensor_type = ("binary_sensor" if (entity == "state") else "sensor")
+        entity_payload['value_template'] = f"{{{{ value_json.{entity} }}}}"
+        entity_payload['unique_id'] = f"wyzesense_{sensor_mac}_{entity}"
+        entity_payload['state_topic'] = mac_topic
+        entity_payload['availability'] = availability_topics
+        entity_payload['availability_mode'] = "all"
+        entity_payload['platform'] = "mqtt"
+        entity_payload['device'] = device_payload
 
-        entity_topic = f"{CONFIG['hass_topic_root']}/{sensor_type}/wyzesense_{sensor_mac}/{entity}/config"
-        mqtt_publish(entity_topic, entity_payload)
-        LOGGER.debug(f"  {entity_topic}")
-        LOGGER.debug(f"  {json.dumps(entity_payload)}")
+        entity_topic = f"{CONFIG['hass_topic_root']}/{'binary_sensor' if (entity == 'state') else 'sensor'}/wyzesense_{sensor_mac}/{entity}/config"
+        mqtt_publish(entity_topic, entity_payload, wait=wait)
 
+        LOGGER.info(f"  {entity_topic}")
+        LOGGER.info(f"  {json.dumps(entity_payload)}")
+    mqtt_publish(f"{CONFIG['self_topic_root']}/{sensor_mac}/status", "online" if SENSORS_STATE[sensor_mac]['online'] else "offline", is_json=False, wait=wait)
 
 # Clear any retained topics in MQTT
-def clear_topics(sensor_mac):
+def clear_topics(sensor_mac, wait=True):
     global CONFIG
     LOGGER.info("Clearing sensor topics")
-    state_topic = f"{CONFIG['self_topic_root']}/{sensor_mac}"
-    mqtt_publish(state_topic, None)
+    mqtt_publish(f"{CONFIG['self_topic_root']}/{sensor_mac}/status", None, wait=wait)
+    mqtt_publish(f"{CONFIG['self_topic_root']}/{sensor_mac}", None, wait=wait)
 
     # clear discovery topics if configured
     if(CONFIG['hass_discovery']):
@@ -339,8 +445,9 @@ def clear_topics(sensor_mac):
                 "binary_sensor" if (entity_type == "state")
                 else "sensor"
             )
-            entity_topic = f"{CONFIG['hass_topic_root']}/{sensor_type}/wyzesense_{sensor_mac}/{entity_type}/config"
-            mqtt_publish(entity_topic, None)
+            mqtt_publish(f"{CONFIG['hass_topic_root']}/{sensor_type}/wyzesense_{sensor_mac}/{entity_type}/config", None, wait=wait)
+            mqtt_publish(f"{CONFIG['hass_topic_root']}/{sensor_type}/wyzesense_{sensor_mac}/{entity_type}", None, wait=wait)
+            mqtt_publish(f"{CONFIG['hass_topic_root']}/{sensor_type}/wyzesense_{sensor_mac}", None, wait=wait)
 
 
 def on_connect(MQTT_CLIENT, userdata, flags, rc):
@@ -354,8 +461,7 @@ def on_connect(MQTT_CLIENT, userdata, flags, rc):
         MQTT_CLIENT.message_callback_add(SCAN_TOPIC, on_message_scan)
         MQTT_CLIENT.message_callback_add(REMOVE_TOPIC, on_message_remove)
         MQTT_CLIENT.message_callback_add(RELOAD_TOPIC, on_message_reload)
-        # Used for alternate MQTT connection method
-        # MQTT_CLIENT.connected_flag = True
+        MQTT_CLIENT.connected_flag = True
         LOGGER.info(f"Connected to MQTT: {mqtt.error_string(rc)}")
     else:
         LOGGER.warning(f"Connection to MQTT failed: {mqtt.error_string(rc)}")
@@ -365,120 +471,170 @@ def on_disconnect(MQTT_CLIENT, userdata, rc):
     MQTT_CLIENT.message_callback_remove(SCAN_TOPIC)
     MQTT_CLIENT.message_callback_remove(REMOVE_TOPIC)
     MQTT_CLIENT.message_callback_remove(RELOAD_TOPIC)
-    # Used for alternate MQTT connection method
-    # MQTT_CLIENT.connected_flag = False
+    MQTT_CLIENT.connected_flag = False
     LOGGER.info(f"Disconnected from MQTT: {mqtt.error_string(rc)}")
 
 
-# Process messages
+# We don't handle any additional messages from MQTT, just log them
 def on_message(MQTT_CLIENT, userdata, msg):
     LOGGER.info(f"{msg.topic}: {str(msg.payload)}")
 
 
 # Process message to scan for new sensors
 def on_message_scan(MQTT_CLIENT, userdata, msg):
-    global SENSORS
+    global SENSORS, CONFIG
+    result = None
     LOGGER.info(f"In on_message_scan: {msg.payload.decode()}")
 
+    # The scan will do a couple additional calls even after the new sensor is found
+    # These calls may time out, so catch it early so we can still add the sensor properly
     try:
         result = WYZESENSE_DONGLE.Scan()
-        LOGGER.debug(f"Scan result: {result}")
-        if (result):
-            sensor_mac, sensor_type, sensor_version = result
-            if (valid_sensor_mac(sensor_mac)):
-                if (SENSORS.get(sensor_mac)) is None:
-                    add_sensor_to_config(
-                        sensor_mac,
-                        sensor_type,
-                        sensor_version
-                    )
-                    if(CONFIG['hass_discovery']):
-                        send_discovery_topics(sensor_mac)
-            else:
-                LOGGER.debug(f"Invalid sensor found: {sensor_mac}")
-        else:
-            LOGGER.debug("No new sensor found")
     except TimeoutError:
         pass
+
+    if (result):
+        LOGGER.info(f"Scan result: {result}")
+        sensor_mac, sensor_type, sensor_version = result
+        if (valid_sensor_mac(sensor_mac)):
+            if (SENSORS.get(sensor_mac)) is None:
+                add_sensor_to_config(sensor_mac, sensor_type, sensor_version)
+                if(CONFIG['hass_discovery']):
+                    # We are in a mqtt callback, so can not wait for new messages to publish
+                    send_discovery_topics(sensor_mac, wait=False)
+        else:
+            LOGGER.info(f"Invalid sensor found: {sensor_mac}")
+    else:
+        LOGGER.info("No new sensor found")
 
 
 # Process message to remove sensor
 def on_message_remove(MQTT_CLIENT, userdata, msg):
-    LOGGER.info(f"In on_message_remove: {msg.payload.decode()}")
     sensor_mac = msg.payload.decode()
+    LOGGER.info(f"In on_message_remove: {sensor_mac}")
 
     if (valid_sensor_mac(sensor_mac)):
+        # Deleting from the dongle may timeout, but we still need to do
+        # the rest so catch it early
         try:
             WYZESENSE_DONGLE.Delete(sensor_mac)
-            clear_topics(sensor_mac)
-            delete_sensor_from_config(sensor_mac)
         except TimeoutError:
             pass
+        # We are in a mqtt callback so cannot wait for new messages to publish
+        clear_topics(sensor_mac, wait=False)
+        delete_sensor_from_config(sensor_mac)
     else:
-        LOGGER.debug(f"Invalid mac address: {sensor_mac}")
+        LOGGER.info(f"Invalid mac address: {sensor_mac}")
 
 
 # Process message to reload sensors
 def on_message_reload(MQTT_CLIENT, userdata, msg):
     LOGGER.info(f"In on_message_reload: {msg.payload.decode()}")
-    init_sensors()
+
+    # Save off the last known state so we don't overwrite new state by re-reading the previously saved file
+    LOGGER.info("Writing Sensors State File")
+    write_yaml_file(os.path.join(CONFIG_PATH, SENSORS_STATE_FILE), SENSORS_STATE)
+
+    # We are in a mqtt callback so cannot wait for new messages to publish
+    init_sensors(wait=False)
 
 
 # Process event
 def on_event(WYZESENSE_DONGLE, event):
-    global SENSORS
+    global SENSORS, SENSORS_STATE
 
-    # List of states that correlate to ON.
-    STATES_ON = ['active', 'open', 'wet']
+    if not INITIALIZED:
+        return
+
+    if event == "ERROR":
+        mqtt_publish(f"{CONFIG['self_topic_root']}/status", "offline", is_json=False)
 
     if (valid_sensor_mac(event.MAC)):
+        if (event.MAC not in SENSORS):
+            add_sensor_to_config(event.MAC, None, None)
+            if(CONFIG['hass_discovery']):
+                send_discovery_topics(event.MAC)
+            LOGGER.warning(f"Linked sensor with mac {event.MAC} automatically added to sensors configuration")
+            LOGGER.warning(f"Please update sensor configuration file {os.path.join(CONFIG_PATH, SENSORS_CONFIG_FILE)} restart the service/reload the sensors")
+
+        # Store last seen time for availability
+        SENSORS_STATE[event.MAC]['last_seen'] = event.Timestamp.timestamp()
+
+        mqtt_publish(f"{CONFIG['self_topic_root']}/{event.MAC}/status", "online", is_json=False)
+
+        # Set back online if it was offline
+        if not SENSORS_STATE[event.MAC]['online']:
+            SENSORS_STATE[event.MAC]['online'] = True
+            LOGGER.info(f"{event.MAC} is back online!")
+
         if (event.Type == "alarm") or (event.Type == "status"):
-            LOGGER.info(f"State event data: {event}")
+            LOGGER.debug(f"State event data: {event}")
             (sensor_type, sensor_state, sensor_battery, sensor_signal) = event.Data
-
-            # Add sensor if it doesn't already exist
-            if (event.MAC not in SENSORS):
-                add_sensor_to_config(event.MAC, sensor_type, None)
-                if(CONFIG['hass_discovery']):
-                    send_discovery_topics(event.MAC)
-
-            # Build event payload
-            event_payload = {
-                'event': event.Type,
-                'available': True,
-                'mac': event.MAC,
-                'device_class': DEVICE_CLASSES.get(sensor_type),
-                'last_seen': event.Timestamp.timestamp(),
-                'last_seen_iso': event.Timestamp.isoformat(),
-                'signal_strength': sensor_signal * -1,
-                'battery': sensor_battery
-            }
-
-            if (CONFIG['publish_sensor_name']):
-                event_payload['name'] = SENSORS[event.MAC]['name']
 
             # Set state depending on state string and `invert_state` setting.
             #     State ON ^ NOT Inverted = True
             #     State OFF ^ NOT Inverted = False
             #     State ON ^ Inverted = False
             #     State OFF ^ Inverted = True
-            event_payload['state'] = int((sensor_state in STATES_ON) ^ (SENSORS[event.MAC].get('invert_state')))
+            sensor_state = int((sensor_state in STATES_ON) ^ (SENSORS[event.MAC].get('invert_state')))
 
-            LOGGER.debug(event_payload)
+            # V2 sensors use a single 1.5v battery and reports half the battery level of other sensors with 3v batteries
+            if sensor_type == "switchv2":
+                sensor_battery = sensor_battery * 2
 
-            state_topic = f"{CONFIG['self_topic_root']}/{event.MAC}"
-            mqtt_publish(state_topic, event_payload)
+            # Adjust battery to max it at 100%
+            sensor_battery = 100 if sensor_battery > 100 else sensor_battery
+
+            # Negate signal strength to match dbm vs percent
+            sensor_signal = sensor_signal * -1
+            sensor_signal = min(max(2 * (sensor_signal + 115), 1), 100)
+
+            # Build event payload
+            event_payload = {
+                'mac': event.MAC,
+                'signal_strength': sensor_signal,
+                'battery': sensor_battery,
+                'state': sensor_state,
+                'last_seen': event.Timestamp.isoformat(),
+            }
+
+            if (CONFIG['publish_sensor_name']):
+                event_payload['name'] = SENSORS[event.MAC]['name']
+
+            mqtt_publish(f"{CONFIG['self_topic_root']}/{event.MAC}", event_payload)
+
+            LOGGER.info(f"{CONFIG['self_topic_root']}/{event.MAC}")
+            LOGGER.info(event_payload)
         else:
-            LOGGER.debug(f"Non-state event data: {event}")
+            LOGGER.info(f"{event}")
 
     else:
         LOGGER.warning("!Invalid MAC detected!")
         LOGGER.warning(f"Event data: {event}")
 
+def Stop():
+    # Stop the dongle first, letting this thread finish anything it might be busy doing, like handling an event
+    WYZESENSE_DONGLE.Stop()
+
+    mqtt_publish(f"{CONFIG['self_topic_root']}/status", "offline", is_json=False)
+
+    # All event handling should now be done, close the mqtt connection
+    MQTT_CLIENT.loop_stop()
+    MQTT_CLIENT.disconnect()
+
+    # Save off the last known state
+    LOGGER.info("Writing Sensors State File")
+    SENSORS_STATE['modified'] = time.time()
+    write_yaml_file(os.path.join(CONFIG_PATH, SENSORS_STATE_FILE), SENSORS_STATE)
+
+    LOGGER.info("********************************** Wyzesense2mqtt stopped ***********************************")
+
 
 if __name__ == "__main__":
     # Initialize logging
     init_logging()
+
+    print("********************************** Wyzesense2mqtt starting **********************************")
 
     # Initialize configuration
     init_config()
@@ -497,18 +653,64 @@ if __name__ == "__main__":
     # Initialize sensor configuration
     init_sensors()
 
+    # All initialized now, so set the flag to allow message event to be processed
+    INITIALIZED = True
+
+    # And mark the service as online
+    mqtt_publish(f"{CONFIG['self_topic_root']}/status", "online", is_json=False)
+
+    dongle_offline = False
+
     # Loop forever until keyboard interrupt or SIGINT
     try:
+        loop_counter = 0
         while True:
-            MQTT_CLIENT.loop_forever(retry_first_connection=False)
+            time.sleep(5)
 
-            # Used for alternate MQTT connection method
-            # signal.pause()
+            # Skip everything while dongle is offline, service needs to be restarted
+            if dongle_offline:
+                continue
+
+            loop_counter += 1
+
+            if not MQTT_CLIENT.connected_flag:
+                LOGGER.warning("Reconnecting MQTT...")
+                MQTT_CLIENT.reconnect()
+
+            if MQTT_CLIENT.connected_flag:
+                mqtt_publish(f"{CONFIG['self_topic_root']}/status", "online", is_json=False)
+
+            # Every minute, try to get the dongle mac address. Hopefully this will tell us if we are having trouble
+            # communicating with the dongle. If so, set the service offline
+            if loop_counter > 12:
+                loop_counter = 0
+                try:
+                    WYZESENSE_DONGLE._GetMac()
+                except TimeoutError:
+                    LOGGER.error("Failed to communicate with dongle")
+                    dongle_offline = True
+                    mqtt_publish(f"{CONFIG['self_topic_root']}/status", "offline", is_json=False)
+
+            # Check for availability of the devices
+            now = time.time()
+            for mac in SENSORS_STATE:
+                if SENSORS_STATE[mac]['online']:
+                    LOGGER.debug(f"Checking availability of {mac}")
+                    # If there is a timeout configured, use that. Must be in seconds.
+                    # If no timeout configured, check if it's a V2 device (quicker reporting period)
+                    # Otherwise, use the longer V1 timeout period
+                    if (SENSORS[mac].get('timeout') is not None):
+                        timeout = SENSORS[mac]['timeout']
+                    elif (SENSORS[mac].get('sw_version') is not None and SENSORS[mac]['sw_version'] in V2_SW):
+                        timeout = DEFAULT_V2_TIMEOUT_HOURS*60*60
+                    else:
+                        timeout = DEFAULT_V1_TIMEOUT_HOURS*60*60
+
+                    if ((now - SENSORS_STATE[mac]['last_seen']) > timeout):
+                        mqtt_publish(f"{CONFIG['self_topic_root']}/{mac}/status", "offline", is_json=False)
+                        LOGGER.warning(f"{mac} has gone offline!")
+                        SENSORS_STATE[mac]['online'] = False
     except KeyboardInterrupt:
         pass
     finally:
-        # Used with alternate MQTT connection method
-        # MQTT_CLIENT.loop_stop()
-
-        MQTT_CLIENT.disconnect()
-        WYZESENSE_DONGLE.Stop()
+        Stop()

--- a/wyzesense2mqtt/wyzesense2mqtt.service
+++ b/wyzesense2mqtt/wyzesense2mqtt.service
@@ -8,6 +8,7 @@ Type=simple
 WorkingDirectory=/wyzesense2mqtt
 ExecStart=/wyzesense2mqtt/service.sh
 Restart=always
+KillSignal=SIGINT
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Added availability topic in HA as V1 devices report state every 4 hours at most, and V2 devices report every 2 hours at most. Added a state file that gets saved on shutdown. This file saves the last seen timestamp and online state for each sensor so that it has consistancy across reboots.

Switched mqtt connection method so it connects faster and availability topics are sent after the connection is active rather than before. This also always the main thread to loop and check availability of the sensors.

The main loop also checks communication with the dongle, by getting the mac address, which allows us to close and reopen the dongle if we lose communication with the device. This is an issue I've been dealing with for a long time.

Fixed shutdown by sending the correct signal in the service file and properly handling it in shutdown. Wait for dongle loop to finish before closing the fd.

Updated logging: set sample logging conf to INFO instead of DEBUG and updated log messages to primarily log mqtt messages/events, etc at this level. Passing in LOGGER to the dongle class so logs from the dongle show up in the log file.

Fix packet parsing to not throw away partial packets which can be parsed correctly when the rest of the message is received.

Signed-off-by: Nathan Bahr <nabahr@users.noreply.github.com>